### PR TITLE
Added guard supplemental gems to Gemfile, fixed weird guard exec errors.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,5 +14,8 @@ gem 'psych'
 
 group :development do
   gem 'guard'
+  gem 'guard-sass'
+  gem 'guard-coffeescript'
+  gem 'guard-livereload'
   gem 'shotgun'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,15 @@ GEM
   specs:
     chronic (0.10.2)
     coderay (1.0.9)
+    coffee-script (2.2.0)
+      coffee-script-source
+      execjs
+    coffee-script-source (1.7.0)
+    em-websocket (0.5.0)
+      eventmachine (>= 0.12.9)
+      http_parser.rb (~> 0.5.3)
+    eventmachine (1.0.3)
+    execjs (2.0.2)
     ffi (1.9.0)
     formatador (0.2.4)
     guard (1.8.3)
@@ -11,14 +20,26 @@ GEM
       lumberjack (>= 1.0.2)
       pry (>= 0.9.10)
       thor (>= 0.14.6)
+    guard-coffeescript (1.4.0)
+      coffee-script (>= 2.2.0)
+      guard (>= 1.1.0)
+    guard-livereload (1.4.0)
+      em-websocket (>= 0.5.0)
+      guard (>= 1.8.0)
+      multi_json (~> 1.7)
+    guard-sass (1.4.0)
+      guard (>= 1.1.0)
+      sass (>= 3.1)
     haml (4.0.3)
       tilt
+    http_parser.rb (0.5.3)
     listen (1.3.1)
       rb-fsevent (>= 0.9.3)
       rb-inotify (>= 0.9)
       rb-kqueue (>= 0.2)
     lumberjack (1.0.4)
     method_source (0.8.2)
+    multi_json (1.8.4)
     posix-spawn (0.3.6)
     pry (0.9.12.2)
       coderay (~> 1.0.5)
@@ -39,6 +60,7 @@ GEM
     rb-kqueue (0.2.0)
       ffi (>= 0.5.0)
     redcarpet (3.0.0)
+    sass (3.2.14)
     shotgun (0.9)
       rack (>= 1.0)
     sinatra (1.4.3)
@@ -57,6 +79,9 @@ PLATFORMS
 DEPENDENCIES
   chronic
   guard
+  guard-coffeescript
+  guard-livereload
+  guard-sass
   haml
   psych
   pygments.rb


### PR DESCRIPTION
Was running into Guard::Sass not found errors when doing a gem install guard-sass (and other gems) manually.  Included the supplemental gems into the Gemfile seemed to resolve the issue - plus we like guard.  At the moment.
